### PR TITLE
small docs fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,9 +67,7 @@ By Way Of Example
 
 Let's say you are plausibly working on a "Server" that will talk to a "Client". Having defined the `Sevices` my-server and my-client you can then define a `Service Group`::
 
-   (dz-defservice-group my-project
-                        my-server
-                        my-client)
+   (dz-defservice-group my-project (my-server my-client))
 
 
 This will provide the M-x functions


### PR DESCRIPTION
The service group definition wasn't correct. The first argument was the name and second was a list of services. It was missing parens in the example. 

I also put it all on one line, but that doesn't really matter. 

Thanks again for writing Dizzee!
