### PR TITLE
Fix CD argument behavior of dz-defservice

### DIFF
--- a/dizzee.el
+++ b/dizzee.el
@@ -88,14 +88,6 @@
   "Return values from `alist' whose KEY matches `regexp'"
   (mapcan #'(lambda (k) (aget alist k)) (dz-regexp-filter (dz-akeys alist) regexp)))
 
-;;;###autoload
-(defmacro dz-dir-excursion (dir body)
-  "Perform BODY having moved to DIR before returning to the current directory"
-  (let ((curdir default-directory))
-    `(progn (cd ,dir)
-            ,body
-            (cd ,curdir))))
-
 ;;
 ;; Emacs utilities
 ;;
@@ -178,8 +170,7 @@ name-running-p
           (message "starting...")
           ,(let ((run `(dz-comint-pop ,service-name ,command (list ,@args))))
              (if cd
-                 `(dz-dir-excursion ,cd
-                                    ,run)
+                 `(let ((default-directory ,cd)) ,run)
                run)))
         (defun ,(intern stop) ()
           "Stop the service"


### PR DESCRIPTION
Specifying CD argument when using dz-defservice macro causes
NAME-start function to move the directory of the current buffer.
This problem is fixed by simply replacing dz-dir-excursion with
a let clause where default-directory is dynamically bound to CD.
