### PR TITLE
fix: removing assoc

### DIFF
--- a/dizzee.el
+++ b/dizzee.el
@@ -39,7 +39,6 @@
 ;; Module level requires
 ;;
 (require 'cl)
-(require 'assoc)
 
 ;;
 ;; Utilities


### PR DESCRIPTION
Remove package assoc. It's obsolete and throws a warning in emacs 24+