### PR TITLE
Updates the installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,9 @@ For now C-h f dz-register-reload
 Installation
 ============
 
-Use el-get with the github repo as a git source.
+Use el-get with the github repo as a git source or you can use straight.el::
+  (use-package dizzee
+  :straight (dizzee :host github :repo "davidmiller/dizzee"))
 
 Or, if you insist, (*grumbles...*) download dizzee.el and::
 

--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,7 @@ Installation
 ============
 
 Use el-get with the github repo as a git source or you can use straight.el::
+
   (use-package dizzee
   :straight (dizzee :host github :repo "davidmiller/dizzee"))
 

--- a/dizzee.el
+++ b/dizzee.el
@@ -38,7 +38,7 @@
 ;;
 ;; Module level requires
 ;;
-(require 'cl)
+(require 'cl-lib)
 
 ;;
 ;; Utilities
@@ -218,21 +218,21 @@ Also provided are the interfaces SERVICE-stop and SERVICE-restart
          ,(concat "Start the service group " service-name)
          (interactive)
          (message ,(concat "Starting " service-name "..."))
-         ,@(loop for call in services
+         ,@(cl-loop for call in services
                  collect `(,(intern (concat (symbol-name call) "-start")))))
 
        (defun ,(intern (concat service-name "-stop")) ()
          ,(concat "Stop the service group " service-name)
          (interactive)
          (message ,(concat "Stopping " service-name))
-         ,@(loop for call in services
+         ,@(cl-loop for call in services
                  collect `(,(intern (concat (symbol-name call) "-stop")))))
 
        (defun ,(intern (concat service-name "-restart")) ()
          ,(concat "Restart the service group " service-name)
          (interactive)
          (message ,(concat "Restarting " service-name))
-         ,@(loop for call in services
+         ,@(cl-loop for call in services
                  collect `(,(intern (concat (symbol-name call) "-restart"))))))))
 
 ;;


### PR DESCRIPTION
Nowadays people tend to use packages like `straight.el` to install the packages, I've added the corresponding installation instructions to use your package with this package manager